### PR TITLE
Reference stylesheet directory. Fixes #2.

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,18 +1,20 @@
-@import "variables";
-@import "syntax-variables";
+@loc: "./styles";
 
-@import "base";
-@import "go";
-@import "c";
-@import "html";
-@import "css";
-@import "git-diff";
-@import "javascript";
-@import "linter";
-@import "markdown";
-@import "php";
-@import "python";
-@import "ruby";
-@import "scala";
-@import "terminal";
-@import "wrap-guide";
+@import "@{loc}/variables";
+@import "@{loc}/syntax-variables";
+
+@import "@{loc}/base";
+@import "@{loc}/go";
+@import "@{loc}/c";
+@import "@{loc}/html";
+@import "@{loc}/css";
+@import "@{loc}/git-diff";
+@import "@{loc}/javascript";
+@import "@{loc}/linter";
+@import "@{loc}/markdown";
+@import "@{loc}/php";
+@import "@{loc}/python";
+@import "@{loc}/ruby";
+@import "@{loc}/scala";
+@import "@{loc}/terminal";
+@import "@{loc}/wrap-guide";


### PR DESCRIPTION
index.less compile was breaking in Atom. Added variable to correctly
reference location of .less files in ./styles
